### PR TITLE
feat: Simple .NET 8 Web API with /health Endpoint

### DIFF
--- a/SkynetHealthApi/Program.cs
+++ b/SkynetHealthApi/Program.cs
@@ -1,0 +1,10 @@
+var builder = WebApplication.CreateBuilder(args);
+var app = builder.Build();
+
+app.MapGet("/health", () => Results.Ok(new
+{
+    status = "healthy",
+    timestamp = DateTime.UtcNow
+}));
+
+app.Run();

--- a/SkynetHealthApi/README.md
+++ b/SkynetHealthApi/README.md
@@ -1,0 +1,37 @@
+# SkynetHealthApi
+
+Eine einfache .NET 8 Web API mit einem `/health` Endpoint.
+
+## Voraussetzungen
+
+- [.NET 8 SDK](https://dotnet.microsoft.com/download/dotnet/8.0)
+
+## Starten
+
+```bash
+cd SkynetHealthApi
+dotnet run
+```
+
+Die API läuft dann auf `http://localhost:5000`.
+
+## Endpoints
+
+### GET /health
+
+Gibt den aktuellen Status der API zurück.
+
+**Response (200 OK):**
+
+```json
+{
+  "status": "healthy",
+  "timestamp": "2026-04-03T20:00:00Z"
+}
+```
+
+## Beispiel
+
+```bash
+curl http://localhost:5000/health
+```

--- a/SkynetHealthApi/SkynetHealthApi.csproj
+++ b/SkynetHealthApi/SkynetHealthApi.csproj
@@ -1,0 +1,9 @@
+<Project Sdk="Microsoft.NET.Sdk.Web">
+
+  <PropertyGroup>
+    <TargetFramework>net8.0</TargetFramework>
+    <Nullable>enable</Nullable>
+    <ImplicitUsings>enable</ImplicitUsings>
+  </PropertyGroup>
+
+</Project>


### PR DESCRIPTION
Closes #1

## Was wurde gemacht?

- .NET 8 Web API Projekt erstellt
- `GET /health` Endpoint implementiert
- Gibt `200 OK` mit `{ "status": "healthy", "timestamp": "..." }` zurück
- README mit Anleitung zum Starten

## Testen

```bash
cd SkynetHealthApi
dotnet run
curl http://localhost:5000/health
```